### PR TITLE
Fix vector store deletion and status display

### DIFF
--- a/src/app/api/bot-creator/route.ts
+++ b/src/app/api/bot-creator/route.ts
@@ -254,8 +254,8 @@ export async function PUT(request: NextRequest) {
       try {
         console.log('Creating vector store for files:', files);
         
-        // Создаем vector store через beta API
-        const vectorStore = await (openai as any).beta.vectorStores.create({
+        // Создаем vector store через основной API
+        const vectorStore = await openai.vectorStores.create({
           name: `Files for ${botConfig.name || 'Assistant'}`
         });
         
@@ -264,7 +264,7 @@ export async function PUT(request: NextRequest) {
         // Добавляем файлы в vector store
         for (const fileId of files) {
           try {
-            await (openai as any).beta.vectorStores.files.create(vectorStore.id, {
+            await openai.vectorStores.files.create(vectorStore.id, {
               file_id: fileId
             });
             console.log('Added file to vector store:', fileId);

--- a/src/app/api/knowledge/documents/route.ts
+++ b/src/app/api/knowledge/documents/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
 
     // Пытаемся получить файлы из vector store
      try {
-       const vectorStoreFiles = await (openai as any).beta.vectorStores.files.list(knowledgeBaseId);
+       const vectorStoreFiles = await openai.vectorStores.files.list(knowledgeBaseId);
       
       const documents: Document[] = await Promise.all(
         vectorStoreFiles.data.map(async (file: any) => {
@@ -44,7 +44,12 @@ export async function GET(request: NextRequest) {
               type: fileDetails.filename.split('.').pop() || 'unknown',
               size: `${Math.round(fileDetails.bytes / 1024 * 100) / 100} KB`,
               uploadDate: new Date(fileDetails.created_at * 1000).toLocaleDateString('ru-RU'),
-              status: file.status === 'completed' ? 'processed' : 'processing'
+              status:
+                file.status === 'completed'
+                  ? 'processed'
+                  : file.status === 'failed'
+                  ? 'failed'
+                  : 'processing'
             };
           } catch (error) {
             console.error('Error fetching file details:', error);
@@ -109,7 +114,7 @@ export async function POST(request: NextRequest) {
       });
 
       // Добавляем файл в vector store
-       await (openai as any).beta.vectorStores.files.create(knowledgeBaseId, {
+       await openai.vectorStores.files.create(knowledgeBaseId, {
          file_id: uploadedFile.id
        });
       
@@ -168,7 +173,7 @@ export async function DELETE(request: NextRequest) {
 
     // Пытаемся удалить файл из vector store
      try {
-       await (openai as any).beta.vectorStores.files.del(knowledgeBaseId, fileId);
+       await openai.vectorStores.files.del(knowledgeBaseId, fileId);
        await (openai as any).files.del(fileId);
     } catch (vectorStoreError) {
       console.log('Vector stores API not available, removing from local storage:', vectorStoreError);

--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
 
     if (id) {
       try {
-        const store = await (openai as any).beta.vectorStores.retrieve(id);
+        const store = await openai.vectorStores.retrieve(id);
 
         const knowledgeBase: KnowledgeBase = {
           id: store.id,
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
 
     // Пытаемся получить vector stores из OpenAI
     try {
-      const vectorStores = await (openai as any).beta.vectorStores.list();
+      const vectorStores = await openai.vectorStores.list();
       
       const knowledgeBases: KnowledgeBase[] = vectorStores.data.map((store: any) => ({
         id: store.id,
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
 
     // Пытаемся создать vector store в OpenAI
     try {
-      const vectorStore = await (openai as any).beta.vectorStores.create({
+      const vectorStore = await openai.vectorStores.create({
         name,
         metadata: {
           description: description || 'No description',
@@ -179,7 +179,7 @@ export async function DELETE(request: NextRequest) {
 
     // Пытаемся удалить vector store из OpenAI
     try {
-      await (openai as any).beta.vectorStores.del(id);
+      await openai.vectorStores.del(id);
     } catch (vectorStoreError) {
       console.log('Vector stores API not available, removing from local storage:', vectorStoreError);
       // Удаляем из локального хранилища

--- a/src/app/knowledge/[id]/page.tsx
+++ b/src/app/knowledge/[id]/page.tsx
@@ -160,6 +160,21 @@ export default function KnowledgeDetail() {
     }
   };
 
+  const handleDeleteKnowledgeBase = async () => {
+    if (!kbId || !confirm('Удалить эту базу знаний?')) return;
+
+    try {
+      const response = await fetch(`/api/knowledge?id=${kbId}`, { method: 'DELETE' });
+
+      if (response.ok) {
+        router.push('/knowledge');
+      }
+    } catch (error) {
+      console.error('Error deleting knowledge base:', error);
+      alert('Ошибка удаления базы знаний');
+    }
+  };
+
   const getFileIcon = (type: string) => {
     switch (type.toLowerCase()) {
       case 'pdf': return '📕';
@@ -216,12 +231,20 @@ export default function KnowledgeDetail() {
                   </span>
                 </div>
               </div>
-              <button
-                onClick={() => router.push('/knowledge')}
-                className="text-gray-400 hover:text-gray-600 transition-colors"
-              >
-                ✕
-              </button>
+              <div className="flex space-x-2">
+                <button
+                  onClick={handleDeleteKnowledgeBase}
+                  className="text-red-600 hover:text-red-800 transition-colors"
+                >
+                  🗑️
+                </button>
+                <button
+                  onClick={() => router.push('/knowledge')}
+                  className="text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
@@ -276,10 +299,20 @@ export default function KnowledgeDetail() {
                       <div className="flex items-center space-x-4 text-sm text-gray-500">
                         <span>Размер: {doc.size}</span>
                         <span>Загружен: {doc.uploadDate}</span>
-                        <span className={`px-2 py-1 rounded-full text-xs ${
-                          doc.status === 'processed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
-                        }`}>
-                          {doc.status === 'processed' ? 'Обработан' : 'В обработке'}
+                        <span
+                          className={`px-2 py-1 rounded-full text-xs ${
+                            doc.status === 'processed'
+                              ? 'bg-green-100 text-green-800'
+                              : doc.status === 'failed'
+                              ? 'bg-red-100 text-red-800'
+                              : 'bg-yellow-100 text-yellow-800'
+                          }`}
+                        >
+                          {doc.status === 'processed'
+                            ? 'Обработан'
+                            : doc.status === 'failed'
+                            ? 'Ошибка'
+                            : 'В обработке'}
                         </span>
                       </div>
                     </div>

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -117,6 +117,21 @@ export default function Knowledge() {
     }
   };
 
+  const handleDeleteKB = async (kb: KnowledgeBase) => {
+    if (!confirm('Вы уверены, что хотите удалить эту базу знаний?')) return;
+
+    try {
+      const response = await fetch(`/api/knowledge?id=${kb.id}`, { method: 'DELETE' });
+
+      if (response.ok) {
+        setKnowledgeBases(prev => prev.filter(item => item.id !== kb.id));
+      }
+    } catch (error) {
+      console.error('Error deleting knowledge base:', error);
+      alert('Ошибка удаления базы знаний');
+    }
+  };
+
 
   if (loading) {
     return (
@@ -204,6 +219,12 @@ export default function Knowledge() {
                       className="flex-1 bg-blue-50 hover:bg-blue-100 text-blue-600 px-3 py-2 rounded text-sm transition-colors"
                     >
                       Открыть
+                    </button>
+                    <button
+                      onClick={() => handleDeleteKB(kb)}
+                      className="flex-1 bg-red-50 hover:bg-red-100 text-red-600 px-3 py-2 rounded text-sm transition-colors"
+                    >
+                      Удалить
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- handle file status `failed` in documents API
- add deletion button for knowledge bases
- support removing knowledge bases from OpenAI
- show file status `Ошибка` when failed

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6875d0f5512c8322a980aa0cfdf2ca1f