### PR TITLE
Fix vector store API calls

### DIFF
--- a/src/app/api/assistant/route.ts
+++ b/src/app/api/assistant/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     
     for (const vectorStoreId of vectorStoreIds) {
       try {
-        const vectorStoreFiles = await openai.vectorStores.files.list(vectorStoreId);
+        const vectorStoreFiles = await openai.beta.vectorStores.files.list(vectorStoreId);
         
         if (vectorStoreFiles && vectorStoreFiles.data) {
           for (const vectorFile of vectorStoreFiles.data) {
@@ -84,7 +84,7 @@ export async function PUT(request: NextRequest) {
         console.log('OpenAI object keys:', Object.keys(openai));
         
         // Создаем vector store через основной API
-        const vectorStore = await openai.vectorStores.create({
+        const vectorStore = await openai.beta.vectorStores.create({
              name: `Files for ${data.name || 'Assistant'}`,
              file_ids: files
            });

--- a/src/app/api/bot-creator/route.ts
+++ b/src/app/api/bot-creator/route.ts
@@ -255,7 +255,7 @@ export async function PUT(request: NextRequest) {
         console.log('Creating vector store for files:', files);
         
         // Создаем vector store через основной API
-        const vectorStore = await openai.vectorStores.create({
+        const vectorStore = await openai.beta.vectorStores.create({
           name: `Files for ${botConfig.name || 'Assistant'}`
         });
         
@@ -264,7 +264,7 @@ export async function PUT(request: NextRequest) {
         // Добавляем файлы в vector store
         for (const fileId of files) {
           try {
-            await openai.vectorStores.files.create(vectorStore.id, {
+            await openai.beta.vectorStores.files.create(vectorStore.id, {
               file_id: fileId
             });
             console.log('Added file to vector store:', fileId);

--- a/src/app/api/knowledge/documents/route.ts
+++ b/src/app/api/knowledge/documents/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
 
     // Пытаемся получить файлы из vector store
      try {
-       const vectorStoreFiles = await openai.vectorStores.files.list(knowledgeBaseId);
+       const vectorStoreFiles = await openai.beta.vectorStores.files.list(knowledgeBaseId);
       
       const documents: Document[] = await Promise.all(
         vectorStoreFiles.data.map(async (file: any) => {
@@ -114,7 +114,7 @@ export async function POST(request: NextRequest) {
       });
 
       // Добавляем файл в vector store
-       await openai.vectorStores.files.create(knowledgeBaseId, {
+       await openai.beta.vectorStores.files.create(knowledgeBaseId, {
          file_id: uploadedFile.id
        });
       
@@ -173,7 +173,7 @@ export async function DELETE(request: NextRequest) {
 
     // Пытаемся удалить файл из vector store
      try {
-       await openai.vectorStores.files.del(knowledgeBaseId, fileId);
+       await openai.beta.vectorStores.files.del(knowledgeBaseId, fileId);
        await (openai as any).files.del(fileId);
     } catch (vectorStoreError) {
       console.log('Vector stores API not available, removing from local storage:', vectorStoreError);

--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
 
     if (id) {
       try {
-        const store = await openai.vectorStores.retrieve(id);
+        const store = await openai.beta.vectorStores.retrieve(id);
 
         const knowledgeBase: KnowledgeBase = {
           id: store.id,
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
 
     // Пытаемся получить vector stores из OpenAI
     try {
-      const vectorStores = await openai.vectorStores.list();
+      const vectorStores = await openai.beta.vectorStores.list();
       
       const knowledgeBases: KnowledgeBase[] = vectorStores.data.map((store: any) => ({
         id: store.id,
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
 
     // Пытаемся создать vector store в OpenAI
     try {
-      const vectorStore = await openai.vectorStores.create({
+      const vectorStore = await openai.beta.vectorStores.create({
         name,
         metadata: {
           description: description || 'No description',
@@ -179,7 +179,7 @@ export async function DELETE(request: NextRequest) {
 
     // Пытаемся удалить vector store из OpenAI
     try {
-      await openai.vectorStores.del(id);
+      await openai.beta.vectorStores.del(id);
     } catch (vectorStoreError) {
       console.log('Vector stores API not available, removing from local storage:', vectorStoreError);
       // Удаляем из локального хранилища


### PR DESCRIPTION
## Summary
- use `openai.beta.vectorStores` API for knowledge routes
- update assistant and bot creator routes to use beta API

## Testing
- `npm install` *(fails: registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875da21ea148322832a9426ab9a9418