### PR TITLE
Fix knowledge base relation query

### DIFF
--- a/src/app/api/bots/knowledge/route.ts
+++ b/src/app/api/bots/knowledge/route.ts
@@ -53,11 +53,11 @@ export async function GET(request: NextRequest) {
         botId: parseInt(botId)
       },
       include: {
-        KnowledgeBase: true
+        knowledgeBase: true
       }
     });
 
-    const knowledgeBases = botKnowledgeBases.map((bkb: any) => bkb.KnowledgeBase);
+    const knowledgeBases = botKnowledgeBases.map((bkb: any) => bkb.knowledgeBase);
 
     return NextResponse.json({
       knowledgeBases
@@ -120,7 +120,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Проверяем, что база знаний принадлежит пользователю
-    const knowledgeBase = await prisma.KnowledgeBase.findFirst({
+    const knowledgeBase = await prisma.knowledgeBase.findFirst({
       where: {
         id: parseInt(knowledgeBaseId),
         userId: decoded.userId


### PR DESCRIPTION
## Summary
- fix relation field name when fetching bot knowledge bases
- use lowercase knowledgeBase client in bot-knowledge attach route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687619804fb48322a519752e1257630e