### PR TITLE
Implement local file storage and retrieval

### DIFF
--- a/KNOWLEDGE_SYSTEM.md
+++ b/KNOWLEDGE_SYSTEM.md
@@ -89,6 +89,12 @@
 - `url`: ссылка на веб-страницу (опционально)
 - `vectorStoreId`: ID базы знаний
 
+#### GET /api/knowledge/documents/{fileId}?knowledgeBaseId=vs_xxx
+Скачать или просмотреть конкретный документ
+
+Запрос возвращает содержимое файла. Его можно открыть в новой вкладке или
+сохранить на диск.
+
 #### DELETE /api/knowledge/documents?fileId=file_xxx&vectorStoreId=vs_xxx
 Удалить документ из базы знаний
 

--- a/src/app/api/knowledge/documents/[fileId]/route.ts
+++ b/src/app/api/knowledge/documents/[fileId]/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { prisma } from '@/lib/prisma';
+import jwt from 'jsonwebtoken';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+// Локальное хранилище из route.ts
+import { localDocuments } from '../route';
+
+// Функция для получения пользователя из токена
+function getUserFromToken(request: NextRequest): { userId: number } | null {
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return null;
+    }
+
+    const token = authHeader.substring(7);
+    const decoded = jwt.verify(
+      token,
+      process.env.JWT_SECRET || 'fallback-secret'
+    ) as any;
+    return { userId: decoded.userId };
+  } catch (error) {
+    console.error('Error verifying token:', error);
+    return null;
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { fileId: string } }
+) {
+  try {
+    const user = getUserFromToken(request);
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const knowledgeBaseId = searchParams.get('knowledgeBaseId');
+
+    if (!knowledgeBaseId) {
+      return NextResponse.json(
+        { error: 'Knowledge base ID is required' },
+        { status: 400 }
+      );
+    }
+
+    const dbKnowledgeBase = await prisma.KnowledgeBase.findFirst({
+      where: {
+        id: parseInt(knowledgeBaseId),
+        userId: user.userId,
+      },
+    });
+
+    if (!dbKnowledgeBase) {
+      return NextResponse.json(
+        { error: 'Knowledge base not found or access denied' },
+        { status: 404 }
+      );
+    }
+
+    try {
+      if (!dbKnowledgeBase.vectorStoreId) {
+        throw new Error('No vector store ID available');
+      }
+
+      const fileRes: any = await openai.files.retrieveContent(params.fileId);
+      const arrayBuffer = await fileRes.arrayBuffer();
+
+      return new NextResponse(Buffer.from(arrayBuffer), {
+        status: 200,
+        headers: {
+          'Content-Type': fileRes.contentType || 'application/octet-stream',
+          'Content-Disposition': `inline; filename="${params.fileId}"`,
+        },
+      });
+    } catch (vectorStoreError) {
+      console.log(
+        'Vector stores API not available, trying local storage:',
+        vectorStoreError
+      );
+
+      const docs = localDocuments[knowledgeBaseId] || [];
+      const doc = docs.find((d) => d.id === params.fileId);
+
+      if (!doc || !doc.file) {
+        return NextResponse.json({ error: 'File not found' }, { status: 404 });
+      }
+
+      const arrayBuffer = await doc.file.arrayBuffer();
+      return new NextResponse(Buffer.from(arrayBuffer), {
+        status: 200,
+        headers: {
+          'Content-Type': doc.file.type || 'application/octet-stream',
+          'Content-Disposition': `inline; filename="${doc.name}"`,
+        },
+      });
+    }
+  } catch (error) {
+    console.error('Error fetching document content:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch document content' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/knowledge/documents/route.ts
+++ b/src/app/api/knowledge/documents/route.ts
@@ -8,7 +8,11 @@ const openai = new OpenAI({
 });
 
 // Локальное хранилище для документов (временное решение)
-let localDocuments: { [knowledgeBaseId: string]: any[] } = {};
+// Сохраняем не только метаданные, но и объект File,
+// чтобы можно было просматривать и скачивать файл
+export let localDocuments: {
+  [knowledgeBaseId: string]: (Document & { file?: File })[]
+} = {};
 
 // Функция для получения пользователя из токена
 function getUserFromToken(request: NextRequest): { userId: number } | null {
@@ -256,7 +260,11 @@ export async function POST(request: NextRequest) {
       if (!localDocuments[knowledgeBaseId]) {
         localDocuments[knowledgeBaseId] = [];
       }
-      localDocuments[knowledgeBaseId].push(document);
+      // Сохраняем вместе с метаданными сам файл
+      localDocuments[knowledgeBaseId].push({
+        ...document,
+        file
+      });
     }
 
     return NextResponse.json({ document });

--- a/src/app/knowledge/[id]/page.tsx
+++ b/src/app/knowledge/[id]/page.tsx
@@ -221,6 +221,69 @@ export default function KnowledgeDetail() {
     }
   };
 
+  const handleViewDocument = async (document: Document) => {
+    try {
+      const token = localStorage.getItem('token');
+      const res = await fetch(
+        `/api/knowledge/documents/${document.id}?knowledgeBaseId=${kbId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (res.ok) {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank');
+        setTimeout(() => URL.revokeObjectURL(url), 10000);
+      } else if (res.status === 401) {
+        router.push('/');
+      } else {
+        const error = await res.json();
+        alert(error.error || 'Ошибка просмотра файла');
+      }
+    } catch (error) {
+      console.error('Error viewing document:', error);
+      alert('Ошибка просмотра файла');
+    }
+  };
+
+  const handleDownloadDocument = async (document: Document) => {
+    try {
+      const token = localStorage.getItem('token');
+      const res = await fetch(
+        `/api/knowledge/documents/${document.id}?knowledgeBaseId=${kbId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (res.ok) {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = document.name;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+      } else if (res.status === 401) {
+        router.push('/');
+      } else {
+        const error = await res.json();
+        alert(error.error || 'Ошибка скачивания файла');
+      }
+    } catch (error) {
+      console.error('Error downloading document:', error);
+      alert('Ошибка скачивания файла');
+    }
+  };
+
   const handleDeleteKnowledgeBase = async () => {
     if (!kbId || !confirm('Удалить эту базу знаний?')) return;
 
@@ -401,10 +464,16 @@ export default function KnowledgeDetail() {
                     </div>
                   </div>
                   <div className="flex space-x-2">
-                    <button className="text-blue-600 hover:text-blue-800 transition-colors">
+                    <button
+                      onClick={() => handleViewDocument(doc)}
+                      className="text-blue-600 hover:text-blue-800 transition-colors"
+                    >
                       👁️
                     </button>
-                    <button className="text-green-600 hover:text-green-800 transition-colors">
+                    <button
+                      onClick={() => handleDownloadDocument(doc)}
+                      className="text-green-600 hover:text-green-800 transition-colors"
+                    >
                       📥
                     </button>
                     <button


### PR DESCRIPTION
## Summary
- keep the uploaded file object in `localDocuments`
- add endpoint to stream a document file
- hook up document view and download buttons
- document file retrieval API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765dc0b138832293ad6e80f49f2adb