### PR TITLE
Add WhatsApp connect endpoint and integration UI

### DIFF
--- a/WHATSAPP_SETUP.md
+++ b/WHATSAPP_SETUP.md
@@ -2,6 +2,8 @@
 
 This project can respond to WhatsApp messages using **whatsapp-web.js**. The integration runs in the Next.js API route `/api/whatsapp/webhook`.
 
+Starting from the new UI, you can initialise the WhatsApp client directly from the Channels page. The endpoint `/api/whatsapp/connect` returns a QR code string which is shown in the browser.
+
 ## 1. Install dependencies
 
 ```bash
@@ -27,13 +29,7 @@ The WhatsApp session data is stored locally using `LocalAuth` from `whatsapp-web
 npm run dev
 ```
 
-2. In a separate terminal, send a request to the webhook to initialise the WhatsApp client:
+2. Откройте раздел "Каналы" в интерфейсе приложения и нажмите кнопку **Подключить WhatsApp**. В браузере появится QR‑код, который нужно просканировать приложением WhatsApp.
 
-```bash
-curl http://localhost:3000/api/whatsapp/webhook
-```
-
-A QR code will appear in the console. Scan it with the WhatsApp application on your phone to authorise the client.
-
-Once authorised, the client will stay connected and handle incoming messages. Voice messages are transcribed with Whisper and the bot reply is sent back through WhatsApp.
+После сканирования клиент будет авторизован и продолжит работу в фоне, обрабатывая входящие сообщения так же, как это описано выше.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "openai": "^5.8.2",
     "prisma": "^6.11.1",
     "qrcode-terminal": "^0.12.0",
+    "qrcode.react": "^1.0.1",
     "whatsapp-web.js": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/api/whatsapp/connect/route.ts
+++ b/src/app/api/whatsapp/connect/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { openai } from '@/lib/assistant';
+import { Client, LocalAuth, Message } from 'whatsapp-web.js';
+
+let whatsappClient: Client | null = null;
+
+async function handleMessage(message: Message) {
+  if (!whatsappClient) return;
+
+  const botIdEnv = process.env.WHATSAPP_BOT_ID;
+  if (!botIdEnv) {
+    console.error('WHATSAPP_BOT_ID env variable not set');
+    return;
+  }
+  const botId = parseInt(botIdEnv);
+  const bot = await prisma.bot.findUnique({ where: { id: botId } });
+  if (!bot || !bot.openaiId) return;
+
+  const contact = await message.getContact();
+  const whatsappId = contact.id._serialized;
+  const pushName = contact.pushname || null;
+
+  const whatsappUser = await prisma.whatsAppUser.upsert({
+    where: { whatsappId },
+    update: { pushName },
+    create: { whatsappId, pushName },
+  });
+
+  let userMessage: string | null = message.body || null;
+
+  if (!userMessage && message.hasMedia && (message.type === 'ptt' || message.type === 'audio')) {
+    try {
+      const media = await message.downloadMedia();
+      if (media) {
+        const buffer = Buffer.from(media.data, 'base64');
+        const file = new File([buffer], 'voice.ogg', { type: media.mimetype || 'audio/ogg' });
+        const transcription = await openai.audio.transcriptions.create({
+          file,
+          model: 'whisper-1',
+        });
+        userMessage = transcription.text;
+      }
+    } catch (e) {
+      console.error('Voice transcription error:', e);
+    }
+  }
+
+  if (!userMessage) return;
+
+  try {
+    const thread = await openai.beta.threads.create();
+    await prisma.message.create({
+      data: {
+        content: userMessage,
+        messageType: 'USER',
+        botId: bot.id,
+        whatsappUserId: whatsappUser.id,
+        whatsappMessageId: message.id._serialized,
+        threadId: thread.id,
+      },
+    });
+
+    const messageWithLanguageInstruction = `${userMessage}\n\n[IMPORTANT INSTRUCTION: Always respond in the same language as the user's message above. If the user writes in Russian - respond in Russian, if in English - respond in English, if in another language - respond in that same language.]`;
+
+    await openai.beta.threads.messages.create(thread.id, {
+      role: 'user',
+      content: messageWithLanguageInstruction,
+    });
+
+    const runResponse = await openai.beta.threads.runs.create(thread.id, {
+      assistant_id: bot.openaiId,
+    });
+
+    let runStatus = await openai.beta.threads.runs.retrieve(runResponse.id, { thread_id: thread.id });
+    while (runStatus.status === 'in_progress' || runStatus.status === 'queued') {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      runStatus = await openai.beta.threads.runs.retrieve(runResponse.id, { thread_id: thread.id });
+    }
+
+    if (runStatus.status === 'completed') {
+      const messages = await openai.beta.threads.messages.list(thread.id);
+      const assistantMessage = messages.data[0];
+      if (assistantMessage.content[0].type === 'text') {
+        const responseText = (assistantMessage.content[0] as any).text.value;
+        const sent = await whatsappClient.sendMessage(message.from, responseText);
+        await prisma.message.create({
+          data: {
+            content: responseText,
+            messageType: 'BOT',
+            botId: bot.id,
+            whatsappUserId: whatsappUser.id,
+            whatsappMessageId: sent.id._serialized,
+            threadId: thread.id,
+          },
+        });
+      }
+    } else {
+      await whatsappClient.sendMessage(message.from, 'Произошла ошибка при обработке запроса.');
+    }
+  } catch (error) {
+    console.error('OpenAI error:', error);
+    await whatsappClient.sendMessage(message.from, 'Произошла ошибка при обработке запроса.');
+  }
+}
+
+export async function GET() {
+  if (whatsappClient) {
+    return NextResponse.json({ status: 'already connected' });
+  }
+
+  whatsappClient = new Client({
+    authStrategy: new LocalAuth(),
+  });
+
+  const qrPromise = new Promise<string>((resolve) => {
+    whatsappClient?.once('qr', (qr: string) => {
+      resolve(qr);
+    });
+  });
+
+  whatsappClient.on('ready', () => {
+    console.log('WhatsApp client is ready');
+  });
+  whatsappClient.on('message', handleMessage);
+  whatsappClient.initialize();
+
+  const qr = await qrPromise;
+  return NextResponse.json({ qr });
+}

--- a/src/app/channels/page.tsx
+++ b/src/app/channels/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Navigation from '../../components/Navigation';
 import ChatWindow from '../../components/ChatWindow';
 import { handleAuthError, createAuthHeaders, isAuthenticated } from '../../lib/authUtils';
+import { QRCode } from 'qrcode.react';
 
 interface Bot {
   id: number;
@@ -51,6 +52,8 @@ export default function Channels() {
   const [availableKnowledgeBases, setAvailableKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [botKnowledgeBases, setBotKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [loadingKnowledge, setLoadingKnowledge] = useState(false);
+  const [whatsappQr, setWhatsappQr] = useState<string | null>(null);
+  const [whatsappStatus, setWhatsappStatus] = useState<string | null>(null);
   const [editForm, setEditForm] = useState({
     name: '',
     description: '',
@@ -206,6 +209,8 @@ export default function Channels() {
       specialization: bot.specialization
     }));
     setShowEditModal(true);
+    setWhatsappQr(null);
+    setWhatsappStatus(null);
     
     // Загружаем доступные базы знаний и базы знаний бота
     await fetchAvailableKnowledgeBases();
@@ -399,6 +404,23 @@ export default function Channels() {
     } catch (error) {
       console.error('Error disabling Telegram:', error);
       alert('Произошла ошибка при отключении');
+    }
+  };
+
+  const handleConnectWhatsApp = async () => {
+    try {
+      setWhatsappStatus(null);
+      setWhatsappQr(null);
+      const response = await fetch('/api/whatsapp/connect');
+      const data = await response.json();
+      if (data.qr) {
+        setWhatsappQr(data.qr);
+      }
+      if (data.status) {
+        setWhatsappStatus(data.status);
+      }
+    } catch (error) {
+      console.error('Error connecting WhatsApp:', error);
     }
   };
 
@@ -881,6 +903,29 @@ export default function Channels() {
                   </div>
                 )}
               </div>
+
+              {/* WhatsApp Integration Section */}
+              <div className="border-t pt-4 mt-6">
+                <h3 className="text-lg font-medium text-gray-800 mb-3">Интеграция с WhatsApp</h3>
+                <div className="space-y-3">
+                  {whatsappQr ? (
+                    <div className="flex flex-col items-center space-y-2">
+                      <QRCode value={whatsappQr} />
+                      <div className="text-sm text-gray-600">Сканируйте QR код приложением WhatsApp</div>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={handleConnectWhatsApp}
+                      className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg text-sm"
+                    >
+                      Подключить WhatsApp
+                    </button>
+                  )}
+                  {whatsappStatus && (
+                    <div className="text-sm text-gray-500">{whatsappStatus}</div>
+                  )}
+                </div>
+              </div>
             </div>
             
             <div className="flex space-x-3 mt-6">
@@ -888,6 +933,8 @@ export default function Channels() {
                 onClick={() => {
                   setShowEditModal(false);
                   setEditingBot(null);
+                  setWhatsappQr(null);
+                  setWhatsappStatus(null);
                 }}
                 className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-2 rounded-lg transition-colors"
               >


### PR DESCRIPTION
## Summary
- implement `/api/whatsapp/connect` to init client and return QR string
- extend channels page with WhatsApp integration section
- include `qrcode.react` dependency
- document the new workflow in `WHATSAPP_SETUP.md`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877915e19dc832285083dec65baad81