### PR TITLE
Add Wazzup webhook setup

### DIFF
--- a/WAZZUP_SETUP.md
+++ b/WAZZUP_SETUP.md
@@ -22,6 +22,10 @@ Set the webhook URL in your Wazzup24 dashboard to:
 https://your-domain.com/api/wazzup/webhook
 ```
 
+## 4. Send webhook URL from the app
+
+On the **Channels** page you will now see an additional field "URL веб-хука". Enter the public URL to your webhook and click **Отправить веб-хук**. The app will send a request to Wazzup24 to register this URL.
+
 Incoming messages will be handled automatically and answered using the selected bot.
 
 ## Notes

--- a/src/app/api/wazzup/setup/route.ts
+++ b/src/app/api/wazzup/setup/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { verifyToken } from '@/lib/auth';
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const token = authHeader.substring(7);
+    const decoded = verifyToken(token);
+    if (!decoded) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+    }
+
+    const { botId, webhookUrl } = await request.json();
+    if (!botId || !webhookUrl) {
+      return NextResponse.json({ error: 'botId and webhookUrl are required' }, { status: 400 });
+    }
+
+    const bot = await prisma.bot.findFirst({
+      where: { id: botId, userId: decoded.userId }
+    });
+
+    if (!bot || !bot.wazzupApiKey) {
+      return NextResponse.json({ error: 'Bot not found or missing Wazzup API key' }, { status: 404 });
+    }
+
+    const resp = await fetch('https://api.wazzup24.com/v3/webhooks', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${bot.wazzupApiKey}`
+      },
+      body: JSON.stringify({
+        webhooksUri: webhookUrl,
+        subscriptions: { messagesAndStatuses: true }
+      })
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error('Wazzup webhook setup failed:', resp.status, text);
+      return NextResponse.json({ error: 'Failed to set webhook' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Wazzup setup error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/channels/page.tsx
+++ b/src/app/channels/page.tsx
@@ -438,6 +438,34 @@ export default function Channels() {
       alert('Произошла ошибка при сохранении');
     }
   };
+  const handleSendWazzupWebhook = async (botId: number) => {
+    const urlInput = document.getElementById("wazzupWebhookUrl") as HTMLInputElement;
+    const webhookUrl = urlInput?.value;
+    if (!webhookUrl) {
+      alert("Введите URL веб-хука");
+      return;
+    }
+    try {
+      const response = await fetch("/api/wazzup/setup", {
+        method: "POST",
+        headers: createAuthHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ botId, webhookUrl })
+      });
+      if (handleAuthError(response, router)) {
+        return;
+      }
+      if (response.ok) {
+        alert("Webhook Wazzup24 установлен");
+      } else {
+        const error = await response.json();
+        alert(`Ошибка: ${error.error}`);
+      }
+    } catch (error) {
+      console.error("Error setting Wazzup webhook:", error);
+      alert("Произошла ошибка при установке веб-хука");
+    }
+  };
+
 
 
   const handleDeleteBot = async (botId: number) => {
@@ -947,6 +975,21 @@ export default function Channels() {
                     className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg text-sm"
                   >
                     Сохранить Wazzup24
+                  </button>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">URL веб-хука</label>
+                    <input
+                      type="text"
+                      id="wazzupWebhookUrl"
+                      placeholder="https://your-domain.com/api/wazzup/webhook"
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <button
+                    onClick={() => handleSendWazzupWebhook(editingBot!.id)}
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm"
+                  >
+                    Отправить веб-хук
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add instructions about configuring webhook from the Channels page
- support Wazzup webhook setup via API
- add form fields in Channels page to send webhook URL

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878b0d0fcc08322805636148c992541