### PR TITLE
Fix wazzup contactId extraction

### DIFF
--- a/src/app/api/wazzup/webhook/route.ts
+++ b/src/app/api/wazzup/webhook/route.ts
@@ -63,7 +63,7 @@ async function handleMessage(payload: any, bot: any) {
   console.log('handleMessage called with payload:', payload);
   const channelId = payload.channelId;
   let text: string | undefined = payload.text;
-  const contactId = payload.contactId || payload.phone;
+  const contactId = payload.contactId || payload.phone || payload.chatId;
   
   console.log('Message details:', {
     channelId,


### PR DESCRIPTION
## Summary
- use `chatId` as a fallback when extracting contactId in Wazzup webhook

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878cac544c08322b88a54e759ad53b7