### PR TITLE
fix: ignore whatsapp echo events

### DIFF
--- a/src/app/api/wazzup/webhook/route.ts
+++ b/src/app/api/wazzup/webhook/route.ts
@@ -64,6 +64,11 @@ async function handleMessage(payload: any, bot: any) {
   const channelId = payload.channelId;
   let text: string | undefined = payload.text;
   const contactId = payload.contactId || payload.phone || payload.chatId;
+
+  if (payload.isEcho) {
+    console.log('Ignoring echo message');
+    return;
+  }
   
   console.log('Message details:', {
     channelId,


### PR DESCRIPTION
## Summary
- ensure the WhatsApp webhook skips echo messages to avoid replying to outgoing events

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d6cafc188322b44414a1cf94b1cd