### PR TITLE
Fix Wazzup message request fields

### DIFF
--- a/src/app/api/wazzup/webhook/route.ts
+++ b/src/app/api/wazzup/webhook/route.ts
@@ -166,7 +166,8 @@ async function handleMessage(payload: any, bot: any) {
         },
         body: JSON.stringify({
           channelId: bot.wazzupChannelId,
-          phone: contactId,
+          chatId: contactId,
+          chatType: 'whatsapp',
           text: responseText
         })
       });


### PR DESCRIPTION
## Summary
- send `chatId` and `chatType` when replying via Wazzup API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dfcb207483229c0c98e63a8c5a72