### PR TITLE
Fix quick reply retrieval

### DIFF
--- a/src/lib/quickReplies.ts
+++ b/src/lib/quickReplies.ts
@@ -9,7 +9,7 @@ export async function checkQuickReply(botId: number, userMessage: string): Promi
     console.log('Normalized message:', normalizedMessage);
     
     // Получаем все быстрые ответы для данного бота
-    const quickReplies = await prisma.quickReplies.findMany({
+    const quickReplies = await prisma.quickReply.findMany({
       where: {
         botId: botId
       }


### PR DESCRIPTION
## Summary
- fix database client usage for quick replies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a08cdfaf483228b93ed4e668c1a58